### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ExpandTable
 完全高仿58同城 点击展开的表格效果
 使用tablelayout 来实现
-###效果图:
+### 效果图:
 ![](https://github.com/haibuzou/ExpandTable/raw/master/art/ScreenGif.gif) 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
